### PR TITLE
Rangeproofs updates: zeroize key_id values after the depth. Add key_id into private nonce

### DIFF
--- a/src/commands/continue_transaction_include_input.c
+++ b/src/commands/continue_transaction_include_input.c
@@ -51,6 +51,13 @@ void processContinueTransactionIncludeInputRequest(__attribute__((unused)) const
 		identifierPath[i] = os_swap_u32(identifierPath[i]);
 	}
 
+	// Go through all unused parts in the identifier path
+	for(size_t i = identifierDepth; i < ARRAYLEN(identifierPath); ++i) {
+
+		// Clear the unused part so it can't carry host-controlled data
+		identifierPath[i] = 0;
+	}
+
 	// Get value from data
 	uint64_t value;
 	memcpy(&value, &data[IDENTIFIER_SIZE], sizeof(value));

--- a/src/commands/continue_transaction_include_output.c
+++ b/src/commands/continue_transaction_include_output.c
@@ -51,6 +51,13 @@ void processContinueTransactionIncludeOutputRequest(__attribute__((unused)) cons
 		identifierPath[i] = os_swap_u32(identifierPath[i]);
 	}
 
+	// Go through all unused parts in the identifier path
+	for(size_t i = identifierDepth; i < ARRAYLEN(identifierPath); ++i) {
+
+		// Clear the unused part so it can't carry host-controlled data
+		identifierPath[i] = 0;
+	}
+
 	// Get value from data
 	uint64_t value;
 	memcpy(&value, &data[IDENTIFIER_SIZE], sizeof(value));

--- a/src/commands/get_bulletproof_components.c
+++ b/src/commands/get_bulletproof_components.c
@@ -145,6 +145,13 @@ void processGetBulletproofComponentsRequest(unsigned short *responseLength, __at
 		identifierPath[i] = os_swap_u32(identifierPath[i]);
 	}
 
+	// Go through all unused parts in the identifier path
+	for(size_t i = identifierDepth; i < ARRAYLEN(identifierPath); ++i) {
+
+		// Clear the unused part so it can't carry host-controlled data
+		identifierPath[i] = 0;
+	}
+
 	// Get value from data
 	uint64_t value;
 	memcpy(&value, &data[sizeof(account) + IDENTIFIER_SIZE], sizeof(value));
@@ -176,8 +183,13 @@ void processGetBulletproofComponentsRequest(unsigned short *responseLength, __at
 		[PROOF_MESSAGE_IDENTIFIER_INDEX] = identifierDepth,
 	};
 
-	// Set proof message's identifier value
-	memcpy(&proofMessage[PROOF_MESSAGE_IDENTIFIER_INDEX + sizeof(identifierDepth)], &data[sizeof(account) + sizeof(identifierDepth)], IDENTIFIER_SIZE - sizeof(identifierDepth));
+	// Go through all parts in the identifier path
+	for(size_t i = 0; i < ARRAYLEN(identifierPath); ++i) {
+
+		// Set proof message's identifier path part in big endian
+		const uint32_t part = os_swap_u32(identifierPath[i]);
+		memcpy(&proofMessage[PROOF_MESSAGE_IDENTIFIER_INDEX + sizeof(identifierDepth) + i * sizeof(part)], &part, sizeof(part));
+	}
 
 	// Initialize blinding factor
 	volatile uint8_t blindingFactor[BLINDING_FACTOR_SIZE];
@@ -271,7 +283,7 @@ void processGetBulletproofComponentsRequest(unsigned short *responseLength, __at
 #endif
 
 			// Get private nonce
-			getPrivateNonce(privateNonce, account, commitment);
+			getPrivateNonce(privateNonce, account, commitment, proofMessage);
 
 // Check if has NGBL
 #ifdef HAVE_NBGL

--- a/src/commands/get_commitment.c
+++ b/src/commands/get_commitment.c
@@ -61,6 +61,13 @@ void processGetCommitmentRequest(unsigned short *responseLength, __attribute__((
 		identifierPath[i] = os_swap_u32(identifierPath[i]);
 	}
 
+	// Go through all unused parts in the identifier path
+	for(size_t i = identifierDepth; i < ARRAYLEN(identifierPath); ++i) {
+
+		// Clear the unused part so it can't carry host-controlled data
+		identifierPath[i] = 0;
+	}
+
 	// Get value from data
 	uint64_t value;
 	memcpy(&value, &data[sizeof(account) + IDENTIFIER_SIZE], sizeof(value));

--- a/src/crypto.c
+++ b/src/crypto.c
@@ -450,13 +450,16 @@ void getRewindNonce(volatile uint8_t *rewindNonce, const uint32_t account, const
 }
 
 // Get private nonce
-void getPrivateNonce(volatile uint8_t *privateNonce, const uint32_t account, const uint8_t *commitment) {
+void getPrivateNonce(volatile uint8_t *privateNonce, const uint32_t account, const uint8_t *commitment, const uint8_t *proofMessage) {
 
 	// Initialize private key
 	volatile cx_ecfp_private_key_t privateKey;
 
 	// Initialize private hash
 	volatile uint8_t privateHash[NONCE_SIZE];
+
+	// Initialize data
+	volatile uint8_t data[COMMITMENT_SIZE + PROOF_MESSAGE_SIZE];
 
 	// Begin try
 	BEGIN_TRY {
@@ -470,8 +473,16 @@ void getPrivateNonce(volatile uint8_t *privateNonce, const uint32_t account, con
 			// Get private hash from the private key
 			getBlake2b(privateHash, sizeof(privateHash), (uint8_t *)privateKey.d, privateKey.d_len, NULL, 0);
 
-			// Get private nonce from the private hash and the commitment
-			getBlake2b(privateNonce, NONCE_SIZE, (uint8_t *)privateHash, sizeof(privateHash), commitment, COMMITMENT_SIZE);
+			// Set data to the commitment and the proof message
+			memcpy((uint8_t *)data, commitment, COMMITMENT_SIZE);
+			memcpy((uint8_t *)&data[COMMITMENT_SIZE], proofMessage, PROOF_MESSAGE_SIZE);
+
+			// Get private nonce from the private hash and the data. Binding the
+			// proof message (it contains the output identifier) makes every
+			// distinct proof message produce distinct tau1/tau2 masks, so
+			// re-proving the same commitment with a different message can't leak
+			// the output's blinding factor.
+			getBlake2b(privateNonce, NONCE_SIZE, (uint8_t *)privateHash, sizeof(privateHash), (uint8_t *)data, sizeof(data));
 
 			// Check if private nonce isn't a valid secret key
 			if(!isValidSecp256k1PrivateKey((uint8_t *)privateNonce, NONCE_SIZE)) {
@@ -486,6 +497,9 @@ void getPrivateNonce(volatile uint8_t *privateNonce, const uint32_t account, con
 
 			// Clear the private hash
 			explicit_bzero((uint8_t *)privateHash, sizeof(privateHash));
+
+			// Clear the data
+			explicit_bzero((uint8_t *)data, sizeof(data));
 
 			// Clear the private key
 			explicit_bzero((cx_ecfp_private_key_t *)&privateKey, sizeof(privateKey));

--- a/src/crypto.h
+++ b/src/crypto.h
@@ -107,7 +107,7 @@ void commitValue(volatile uint8_t *commitment, const uint64_t value, const uint8
 void getRewindNonce(volatile uint8_t *rewindNonce, const uint32_t account, const uint8_t *commitment);
 
 // Get private nonce
-void getPrivateNonce(volatile uint8_t *privateNonce, const uint32_t account, const uint8_t *commitment);
+void getPrivateNonce(volatile uint8_t *privateNonce, const uint32_t account, const uint8_t *commitment, const uint8_t *proofMessage);
 
 // Get address private key
 void getAddressPrivateKey(volatile cx_ecfp_private_key_t *addressPrivateKey, const uint32_t account, const uint32_t index, const cx_curve_t curve);


### PR DESCRIPTION
This PR address the problem:

In app-mimblewimblecoin, each output's keys derive from a fixed-length key path (the "identifier") of which only the first `identifierDepth` words are meaningful. The blinding factor `γ`, the commitment, and the proof nonces `tau1,tau2` all depend only on those used words (`deriveChildKey` loops for `i < pathLength`, `tau1,tau2 = createScalarsFromChaCha20(privateNonce)`, `privateNonce = f(account,commitment)`). But unused trailing words are not validated and are copied into the range proof's proof message, which feeds the Fiat–Shamir challenges `x, z`.

So a malicious host can request several proofs for the same output, varying only trailing padding: `tau1,tau2,γ` stay fixed while `x,z` change. Each proof publishes `tau_x = tau1·x + tau2·x² + z²·γ (mod n)`, so three requests give three equations that solve for `γ` — the secret that hides the output's amount and is needed to spend it.

In order to address that we did key_id values.
But also wallet has plans to use different key_id for the same commitment. In order to address that, we changed privateNonceDefinition from  privateNonce = f(account,commitment)  to privateNonce = f(account,commitment, key_id).  In this case different key_id will trigger generation of different `tau1,tau2`